### PR TITLE
Update to php 7.1, php-ast 0.1.4, and alpine 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.6
 
 ADD repositories /etc/apk
 
@@ -37,21 +37,22 @@ RUN apk --update add bash \
 	php7-zip \
 	php7-zlib
 
+# In alpine 3.6, /usr/bin/php is php 7.1.x
+
 RUN apk --update add bash \
 	autoconf \
 	make \
 	build-base \
 	php7-dev && \
-	ln -s /usr/bin/php7 /usr/bin/php && \
-	wget -O v0.1.1.tar.gz https://github.com/nikic/php-ast/archive/v0.1.1.tar.gz && \
-	tar -zxvf v0.1.1.tar.gz && \
-	cd php-ast-0.1.1 && \
+	wget -O v0.1.4.tar.gz https://github.com/nikic/php-ast/archive/v0.1.4.tar.gz && \
+	tar -zxvf v0.1.4.tar.gz && \
+	cd php-ast-0.1.4 && \
 	phpize7 && \
 	./configure --prefix=/usr --with-php-config=/usr/bin/php-config7 && \
 	make -j3 && \
 	make install && \
 	cd .. && \
-	rm -Rf php-ast-0.1.1 && \
+	rm -Rf php-ast-0.1.4 && \
 	apk del php7-dev \
 	autoconf \
 	make \

--- a/repositories
+++ b/repositories
@@ -1,3 +1,3 @@
-http://dl-cdn.alpinelinux.org/alpine/v3.3/main
-http://dl-cdn.alpinelinux.org/alpine/v3.3/community
+http://dl-cdn.alpinelinux.org/alpine/v3.6/main
+http://dl-cdn.alpinelinux.org/alpine/v3.6/community
 http://dl-cdn.alpinelinux.org/alpine/edge/testing


### PR DESCRIPTION
php-ast 0.1.4 is needed to support php 7.1

The php7 package currently installs php 7.1.5

Fixes #1

This project is currently used by https://github.com/etsy/phan/blob/master/plugins/codeclimate/Dockerfile

- https://github.com/etsy/phan/issues/826